### PR TITLE
Fix timestamps

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -66,7 +66,11 @@ func SetActivity(activity Activity) error {
 
 func getNonce() string {
 	buf := make([]byte, 16)
-	rand.Read(buf)
+	_, err := rand.Read(buf)
+	if err != nil {
+		fmt.Println(err)
+	}
+
 	buf[6] = (buf[6] & 0x0f) | 0x40
 
 	return fmt.Sprintf("%x-%x-%x-%x-%x", buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:])

--- a/client/inputMapper.go
+++ b/client/inputMapper.go
@@ -39,9 +39,9 @@ type Party struct {
 // Timestamps holds unix timestamps for start and/or end of the game
 type Timestamps struct {
 	// unix time (in milliseconds) of when the activity started
-	Start time.Time
+	Start *time.Time
 	// unix time (in milliseconds) of when the activity ends
-	End time.Time
+	End *time.Time
 }
 
 // Secrets holds secrets for Rich Presence joining and spectating
@@ -80,10 +80,14 @@ func mapActivity(activity *Activity) *PayloadActivity {
 		},
 	}
 
-	if activity.Timestamps != nil {
+	if activity.Timestamps != nil && activity.Timestamps.Start != nil {
+		start := uint64(activity.Timestamps.Start.UnixNano() / 1e6)
 		final.Timestamps = &PayloadTimestamps{
-			Start: uint64(activity.Timestamps.Start.UnixNano() / 1e6),
-			End:   uint64(activity.Timestamps.End.UnixNano() / 1e6),
+			Start: &start,
+		}
+		if activity.Timestamps.End != nil {
+			end := uint64(activity.Timestamps.End.UnixNano() / 1e6)
+			final.Timestamps.End = &end
 		}
 	}
 

--- a/client/types.go
+++ b/client/types.go
@@ -38,8 +38,8 @@ type PayloadParty struct {
 }
 
 type PayloadTimestamps struct {
-	Start uint64 `json:"start,omitempty"`
-	End   uint64 `json:"end,omitempty"`
+	Start *uint64 `json:"start,omitempty"`
+	End   *uint64 `json:"end,omitempty"`
 }
 
 type PayloadSecrets struct {

--- a/example/main.go
+++ b/example/main.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/ananagame/rich-go/client"
 	"time"
+
+	"github.com/ananagame/rich-go/client"
 )
 
 func main() {
@@ -12,6 +13,7 @@ func main() {
 		panic(err)
 	}
 
+	now := time.Now()
 	err = client.SetActivity(client.Activity{
 		State:      "Heyy!!!",
 		Details:    "I'm running on rich-go :)",
@@ -25,7 +27,7 @@ func main() {
 			MaxPlayers: 24,
 		},
 		Timestamps: &client.Timestamps{
-			Start: time.Now(),
+			Start: &now,
 		},
 	})
 

--- a/ipc/ipc.go
+++ b/ipc/ipc.go
@@ -46,7 +46,7 @@ func Read() string {
 		buffer.WriteByte(buf[i])
 	}
 
-	return string(buffer.Bytes())
+	return buffer.String()
 }
 
 // Send opcode and payload to the unix socket

--- a/ipc/ipc.go
+++ b/ipc/ipc.go
@@ -64,7 +64,10 @@ func Send(opcode int, payload string) string {
 	}
 
 	buf.Write([]byte(payload))
-	socket.Write(buf.Bytes())
+	_, err = socket.Write(buf.Bytes())
+	if err != nil {
+		fmt.Println(err)
+	}
 
 	return Read()
 }


### PR DESCRIPTION
Fixes https://github.com/hugolgst/rich-go/issues/6

The `End` field in the payload should be omitted if no end time is provided, making discord display a time elapsed instead of time remaining status. However the changes provided here break the current API it takes a `*time.Time` instead of `time.Time`, though it's an easy fix for any end user.