### PR TITLE
Fix stale socket issue on Linux

### DIFF
--- a/ipc/ipc_notwin.go
+++ b/ipc/ipc_notwin.go
@@ -1,19 +1,22 @@
+//go:build !windows
 // +build !windows
 
 package ipc
 
 import (
+	"fmt"
 	"net"
 	"time"
 )
 
-// OpenSocket opens the discord-ipc-0 unix socket
+// Dials discord-pic-[0,9] sockets and returns an error if none connect.
 func OpenSocket() error {
-	sock, err := net.DialTimeout("unix", GetIpcPath()+"/discord-ipc-0", time.Second*2)
-	if err != nil {
-		return err
+	var err error
+	for i := 0; i < 10; i++ {
+		if sock, err := net.DialTimeout("unix", GetIpcPath()+fmt.Sprintf("/discord-ipc-%d", i), time.Second*2); err == nil {
+			socket = sock
+			return nil
+		}
 	}
-
-	socket = sock
-	return nil
+	return fmt.Errorf("dialed sockets discord-ipc-[0,9], all failed, last error %w", err)
 }


### PR DESCRIPTION
I ran into an issue on Linux where sometimes the `discord-ipc-0` socket was stale, yielding the error `dial unix /run/user/1000/discord-ipc-0: connect: connection refused`. It seems pretty difficult to actually reproduce this issue in an organic way, but I believe if the `discord-ipc-0` socket still exists for whatever reason when Discord is opened, it creates a new one.

I was using another library in python, [Discord-RPC](https://github.com/Senophyx/Discord-RPC), and it tries sockets 0 through 9. Implementing that here resolves the issue. I didn't touch the implementation in ` ipc_windows.go` as I don't have a windows install to test it on, but perhaps that would be an issue there as well?